### PR TITLE
Ext commands and diff view

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
       ],
       "explorer/context": [
         {
-          "when": "resourceExtname =~ /\\.(json|jsonc)$/i",
+          "when": "resourceExtname =~ /\\.(json|jsonc)$/i && epacman.isCustomPolicy",
           "command": "epacman.validateCurrentFile",
           "group": "epacman"
         },
@@ -100,7 +100,7 @@
           "group": "epacman"
         },
         {
-          "when": "resourceExtname =~ /\\.(json|jsonc)$/i",
+          "when": "resourceExtname =~ /\\.(json|jsonc)$/i && epacman.isCustomPolicy",
           "command": "epacman.viewPolicyCard",
           "group": "epacman"
         },

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -273,5 +273,4 @@ export function registerCommands(context: vscode.ExtensionContext, validationEng
     );
     
     logger.info("Commands registered successfully");
-    logger.info("Commands registered successfully");
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -332,7 +332,6 @@ export async function activate(context: vscode.ExtensionContext) {
         });
         
         logger.info("ePacMan extension activated successfully");
-        vscode.window.showInformationMessage("ePacMan extension activated");
     } catch (error: any) {
         logger.error("Failed to activate ePacMan extension", error);
         vscode.window.showErrorMessage(`Failed to activate ePacMan extension: ${error.message}`);

--- a/src/github/file-comparison.ts
+++ b/src/github/file-comparison.ts
@@ -311,11 +311,12 @@ export class FileComparisonUtility {
             await vscode.workspace.applyEdit(workspaceEdit);
             
             // Show the diff between normalized versions
+            // Swap the order of parameters to show local first and GitHub second
             await vscode.commands.executeCommand(
                 'vscode.diff',
-                githubUri,
-                localTempUri,
-                `${policyName}: GitHub ↔ Local (Normalized View)`
+                localTempUri,  // Show local file first
+                githubUri,     // Show GitHub version second
+                `${policyName}: Local ↔ GitHub (Normalized View)`  // Updated title to match new order
             );
             
             this.logger.info(`Showing normalized diff view for policy ${policyName}`);

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -83,9 +83,6 @@ suite('Extension Test Suite', () => {
     const originalLogger = require('../../logging').Logger;
     require('../../logging').Logger.getInstance = getInstanceStub;
     
-    // Mock vscode.window.showInformationMessage
-    const showInfoStub = sinon.stub(vscode.window, 'showInformationMessage').resolves();
-    
     try {
       // Activate the extension
       await myExtensionProxy.activate(context);
@@ -97,20 +94,21 @@ suite('Extension Test Suite', () => {
       assert.strictEqual(registerCommandsStub.calledOnce, true, 'registerCommands should be called once');
       assert.strictEqual(registerCommandsStub.firstCall.args[0], context, 'registerCommands should be called with context');
       
-      // Verify that the extension activated successfully
-      assert.strictEqual(showInfoStub.calledOnce, true, 'showInformationMessage should be called once');
-      assert.strictEqual(showInfoStub.firstCall.args[0], 'ePacMan extension activated', 'Activation message should be shown');
-      
       // Verify that the logger was used
       assert.strictEqual(loggerStub.info.called, true, 'Logger.info should be called');
+      
+      // Verify the correct activation success message was logged
+      assert.strictEqual(
+        loggerStub.info.calledWith("ePacMan extension activated successfully"), 
+        true, 
+        'Logger.info should be called with the correct activation message'
+      );
+      
       assert.strictEqual(loggerStub.debug.called, true, 'Logger.debug should be called');
     } finally {
       // Restore the original functions
       require('../../commands').registerCommands = originalRegisterCommands;
       require('../../logging').Logger.getInstance = originalLogger.getInstance;
-      
-      // Restore stubs
-      showInfoStub.restore();
     }
   });
   


### PR DESCRIPTION
- Extension now only show commands when editing EPAC files as some commands were only looking at json/jsonc files.
- The github comparison diff view has been reversed to properly show what's being added.